### PR TITLE
Relink local plugins on update

### DIFF
--- a/autoload/packager/plugin.vim
+++ b/autoload/packager/plugin.vim
@@ -99,7 +99,7 @@ endfunction
 
 function! s:plugin.local_command() abort
   if executable('ln')
-    return ['ln', '-s', fnamemodify(self.url, ':p'), self.dir]
+    return ['ln', '-sf', fnamemodify(self.url, ':p'), self.dir]
   endif
 
   if has('win32') && executable('mklink')


### PR DESCRIPTION
When running `packager#update()`, if a local plugin has already been linked, the linking operation will exit with a status code of 1. To prevent this I've added the `f` flag to the `ln` command which will remove the link if it already exists, and then make a new link. This not only prevents the error on update, but also handles the case where the target of the link has moved or changed.