### PR TITLE
remove join() call from packager#utils#system()

### DIFF
--- a/autoload/packager/utils.vim
+++ b/autoload/packager/utils.vim
@@ -1,7 +1,7 @@
 scriptencoding utf8
 function! packager#utils#system(cmds) abort
   let l:save_shell = packager#utils#set_shell()
-  let l:cmd_output = systemlist(join(a:cmds, ' '))
+  let l:cmd_output = systemlist(a:cmds)
   call packager#utils#restore_shell(l:save_shell)
   return l:cmd_output
 endfunction


### PR DESCRIPTION
`systemlist()` will accept a list as an argument so the join is only necessary if the command should be run through the shell, which doesn't seem to be necessary anywhere this is currently used.

Removing this does have actual performance benefits based on some profiling I did. To create the following profile data, I used these commands:

```vim
:profile start $filename
:profile func *packager
:PackStatus (three times)
:profile stop
```

`PackStatus` is a command in my personal vimrc (see [here](https://github.com/deathlyfrantic/dotfiles/blob/master/nvim/plugin/package.vim#L60)) that calls `packager#init()`, adds all of my plugins to it, then calls `packager#status()`.

I ran `PackStatus` three times just to get more data to average. Nothing changed between each of the three individual runs, and the only change between the two groups was removing the `join()` call in `packager#utils#system()`.

For brevity I'm only going to include the time for the `packager#utils#system()` call - its performance is all we care about anyway for this particular commit. It is by far the most expensive (in terms of time) function in the entire process.

With join:

```
FUNCTIONS SORTED ON SELF TIME
count  total (s)   self (s)  function
  564   5.511609   0.050797  packager#utils#system()
```

Without join:

```
FUNCTIONS SORTED ON SELF TIME
count  total (s)   self (s)  function
  564   4.050826   0.065706  packager#utils#system()
```

So just removing the `join()` call saves us about 1.5s over the course of three runs, or approximately 0.5s per run. For reference, I have 47 plugins. (Also note this means this function is called four times per plugin [47 * 4 * 3 = 564] - I'm going to try to reduce that in another commit.)