### PR TITLE
Unify path separator in defaults.dir

### DIFF
--- a/autoload/packager.vim
+++ b/autoload/packager.vim
@@ -2,7 +2,7 @@ scriptencoding utf8
 let s:packager = {}
 let s:slash = exists('+shellslash') && !&shellslash ? '\' : '/'
 let s:defaults = {
-      \ 'dir': printf('%s%s%s', split(&packpath, ',')[0], s:slash, 'pack'.s:slash.'packager'),
+      \ 'dir': printf('%s%s%s', substitute(split(&packpath, ',')[0], '\(\\\|\/\)', s:slash, 'g'), s:slash, 'pack'.s:slash.'packager'),
       \ 'depth': 5,
       \ 'jobs': 8,
       \ 'window_cmd': 'vertical topleft new',


### PR DESCRIPTION
So filter with l:folders in packager.clean() works again.

Since commit e55a08af (2020-01-04) :PackagerClean offers to delete all plugins
This line was removed from function s:packager.clean()
-  let l:plugins = values(map(copy(self.processed_plugins), 'substitute(v:val.dir, ''\(\\\|\/\)'', s:slash, ''g'')'))

Problem occurs on Windows because &packpath can contain backward and forward slashes
